### PR TITLE
Make sure we always return -1 from getColumnIndex() if column not found

### DIFF
--- a/WithIdCursorWrapper.java
+++ b/WithIdCursorWrapper.java
@@ -124,7 +124,9 @@ public class WithIdCursorWrapper extends CursorWrapper {
             if (throwException) {
                 return super.getColumnIndexOrThrow(columnName) + 1;
             } else {
-                return super.getColumnIndex(columnName) + 1;
+                // -1 means column not found
+                int i = super.getColumnIndex(columnName);
+                return i >= 0 ? i + 1 : i;
             }
         } else if (mIdPosition == ID_FIRST) {
             // by now, columnName must be _id, added as the first column:


### PR DESCRIPTION
In the case where a column is not found, and we're calling the non-throwing version of `getColumnIndex()`, we must always return `-1`. The code would originally return 0 in this case, because it was always adding 1 to the index retrieved from `super.getColumnIndex(columnName)`.
